### PR TITLE
OVDX-7043: Fixing issue with unknown attribute error

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -33,6 +33,14 @@ module Delayed
       class Job < ::ActiveRecord::Base
         include Delayed::Backend::Base
 
+        def initialize(attributes = nil)
+          unless Job.column_names.include?(:distributed_request_id.to_s)
+            attributes&.delete(:distributed_request_id) if attributes&.include?(:distributed_request_id)
+            attributes&.delete(:distributed_request_id.to_s) if attributes&.include?(:distributed_request_id.to_s)
+          end
+          super
+        end
+
         if ::ActiveRecord::VERSION::MAJOR < 4 || defined?(::ActiveRecord::MassAssignmentSecurity)
           attr_accessible :priority, :run_at, :queue, :payload_object,
                           :failed_at, :locked_at, :locked_by, :handler


### PR DESCRIPTION
Validation of this change:

1. In the `ovation.io` repo, change the `delayed_job_active_record` gem branch to `feature/johnsonrw82/ovdx-7000-request-id`
2. Run `bundle install`
3. Open the Rails console
4. Run `Delayed::Job.new(distributed_request_id: SecureRandom.uuid)`
5. Drop the column from the `delayed_jobs` table
6. Re-run
7. The expected result is no `ActiveModel::UnknownAttributeError` should be raised