### PR TITLE
OVDX-8556 add index hint to delayed job

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }  
   spec.add_dependency "activerecord", [">= 3.0", "< 6.2"]
   spec.add_dependency "delayed_job",  [">= 3.0", "< 5"]
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
@@ -12,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.name           = "delayed_job_active_record"
   spec.require_paths  = ["lib"]
   spec.summary        = "ActiveRecord backend for DelayedJob"
-  spec.version        = "4.1.5"
+  spec.version        = "4.1.6"
 end

--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |spec|
   spec.metadata = {
     "rubygems_mfa_required" => "true"
-  }  
+  }
   spec.add_dependency "activerecord", [">= 3.0", "< 6.2"]
   spec.add_dependency "delayed_job",  [">= 3.0", "< 5"]
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]

--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.metadata = {
-    'rubygems_mfa_required' => 'true'
+    "rubygems_mfa_required" => "true"
   }  
   spec.add_dependency "activerecord", [">= 3.0", "< 6.2"]
   spec.add_dependency "delayed_job",  [">= 3.0", "< 5"]

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -69,7 +69,7 @@ module Delayed
 
         def self.ready_to_run(worker_name, max_run_time)
           rtr = where(
-            "(run_at <= ? AND (locked_at IS NULL OR locked_at < ?) OR locked_by = ?) AND failed_at IS NULL",
+            "((run_at <= ? AND (locked_at IS NULL OR locked_at < ?)) OR locked_by = ?) AND failed_at IS NULL",
             db_time_now,
             db_time_now - max_run_time,
             worker_name

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -68,12 +68,17 @@ module Delayed
         set_delayed_job_table_name
 
         def self.ready_to_run(worker_name, max_run_time)
-          where(
-            "((run_at <= ? AND (locked_at IS NULL OR locked_at < ?)) OR locked_by = ?) AND failed_at IS NULL",
+          rtr = where(
+            "(run_at <= ? AND (locked_at IS NULL OR locked_at < ?) OR locked_by = ?) AND failed_at IS NULL",
             db_time_now,
             db_time_now - max_run_time,
             worker_name
           )
+
+          ## we want to be able to shut this off from the outside if it breaks
+          return rtr unless ENV['DJ_INDEX_KILLSWITCH'].nil?
+
+          rtr.from([Arel.sql("#{quoted_table_name} FORCE INDEX(index_delayed_jobs_lock_query_with_queue)")])
         end
 
         def self.before_fork

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -76,7 +76,7 @@ module Delayed
           )
 
           ## we want to be able to shut this off from the outside if it breaks
-          return rtr unless ENV['DJ_INDEX_KILLSWITCH'].nil?
+          return rtr unless ENV["DJ_INDEX_KILLSWITCH"].nil?
 
           rtr.from([Arel.sql("#{quoted_table_name} FORCE INDEX(index_delayed_jobs_lock_query_with_queue)")])
         end


### PR DESCRIPTION
Adds an index hint to the job selection query. This hint can be disabled using an environment kill switch. Set `DJ_INDEX_KILLSWITCH` to any value and restart the container.