### PR TITLE
OVDX-8556 add index hint to delayed job, correct parent

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -76,12 +76,17 @@ module Delayed
         set_delayed_job_table_name
 
         def self.ready_to_run(worker_name, max_run_time)
-          where(
-            "(run_at <= ? AND (locked_at IS NULL OR locked_at < ?) OR locked_by = ?) AND failed_at IS NULL",
+          rtr = where(
+            "((run_at <= ? AND (locked_at IS NULL OR locked_at < ?)) OR locked_by = ?) AND failed_at IS NULL",
             db_time_now,
             db_time_now - max_run_time,
             worker_name
           )
+
+          ## we want to be able to shut this off from the outside if it breaks
+          return rtr unless ENV["DJ_INDEX_KILLSWITCH"].nil?
+
+          rtr.from([Arel.sql("#{quoted_table_name} FORCE INDEX(index_delayed_jobs_lock_query_with_queue)")])
         end
 
         def self.before_fork


### PR DESCRIPTION
Basing off @johnsonrw82's changes which is what we're using in lab-services today (v4.1.4). The other version, v4.1.5, is an experiment that Jonathan was working on, probably during a ruby / rails upgrade pass.